### PR TITLE
Prevent sending for review if current git dir is dirty.

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -12,6 +12,12 @@ if [ "${BRANCH}" == "master" ]; then
   exit 1
 fi
 
+# Ensures that current dir is clean.
+if [ -n "$(git diff HEAD --shortstat 2> /dev/null | tail -n1)" ]; then
+  echo "Current git status is dirty. Commit, stash or revert your changes before sending for review." 1>&2
+  exit 3
+fi
+
 git push -u origin "${BRANCH}"
 
 readonly MESSAGE_FILE=$(mktemp)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/22) &emsp; Multiple assignees:&emsp;<img alt="@dedan" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/196905?s=40&v=3">&nbsp;<a href="/bayesimpact/bayes-developer-setup/pulls/assigned/dedan">dedan</a>,&emsp;<img alt="@florianjourda" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/4361853?s=40&v=3">&nbsp;<a href="/bayesimpact/bayes-developer-setup/pulls/assigned/florianjourda">florianjourda</a>
<!-- Reviewable:end -->
