### PR TITLE
Always prefix username on remote repo to avoid conflict while easing the pain locally.

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -26,7 +26,8 @@ if [ -z "$(git diff $(git merge-base HEAD "${BASE_BRANCH}") --shortstat 2> /dev/
   exit 4
 fi
 
-git push -u "${REMOTE_REPO}" "${BRANCH}"
+readonly USERNAME=$(git config user.email | sed -e "s/@.*$//")
+git push -u "${REMOTE_REPO}" "${BRANCH}:${USERNAME}-${BRANCH}"
 
 readonly MESSAGE_FILE=$(mktemp)
 


### PR DESCRIPTION
+@dedan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/49)
<!-- Reviewable:end -->
