### PR TITLE
Fix git-review now that the local branch and the remote branch do not share the same name.

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -27,7 +27,8 @@ if [ -z "$(git diff $(git merge-base HEAD "${BASE_BRANCH}") --shortstat 2> /dev/
 fi
 
 readonly USERNAME=$(git config user.email | sed -e "s/@.*$//")
-git push -u "${REMOTE_REPO}" "${BRANCH}:${USERNAME}-${BRANCH}"
+readonly REMOTE_BRANCH="${USERNAME}-${BRANCH}"
+git push -u "${REMOTE_REPO}" "${BRANCH}:${REMOTE_BRANCH}"
 
 readonly MESSAGE_FILE=$(mktemp)
 
@@ -43,7 +44,7 @@ if [ -x "${GIT_REVIEW_HOOK}" ]; then
   "${GIT_REVIEW_HOOK}" >> "${MESSAGE_FILE}"
 fi
 
-hub pull-request -F "${MESSAGE_FILE}" -a "${REVIEWER}" | \
+hub pull-request -F "${MESSAGE_FILE}" -a "${REVIEWER}" -h "${REMOTE_BRANCH}" | \
   sed -e "s/github.com/reviewable.io\/reviews/;s/pull\///"
 
 rm "${MESSAGE_FILE}"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/50)
<!-- Reviewable:end -->
