### PR TITLE
[Hooks] Add a commit-msg hook to enforce our styleguide.

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Commit message hook to ensure the message follows our guidelines.
+# See go/wiki/CommitMessageStyleGuide.
+# To add them to a project, use `git config core.hooksPath $BAYES_DEV_SETUP_FOLDER/hooks`.
+
+. "$(git --exec-path)/git-sh-setup"  # for die
+readonly COMMIT_MSG=$1
+
+readonly CONTEXT_MAX_LENGTH=15
+readonly SUBJECT_MAX_LENGTH=59
+readonly BODY_MAX_LENGTH=72
+
+# Ensure context format and length.
+grep -qP '^\[[^\]]{2,'"$CONTEXT_MAX_LENGTH"'}\]' <<< "$COMMIT_MSG" ||
+  die 'Message should start with a bracketed topic of maximum length '"$CONTEXT_MAX_LENGTH"'. E.g. "[Clean Code]"'
+
+# Ensure subject format and length.
+readonly SUBJECT=$(head -n1 <<< "$COMMIT_MSG")
+grep -qP '(?<=\] ).{1,'"$SUBJECT_MAX_LENGTH"'}\.$' <<< "$SUBJECT" ||
+  die 'Commit message should be no more than '"$SUBJECT_MAX_LENGTH"`
+  `' characters long, start with an uppercase letter and end with a period.
+  Example: "Fix the padding on the landing title."'
+if [[ "$SUBJECT" == "$COMMIT_MSG" ]]; then
+  exit
+fi
+
+# Ensure subject is separated from the body with an empty line.
+head -n2 <<< "$COMMIT_MSG" | tail -n1 | grep -qv '.' ||
+  die 'Commit subject should be separated from body with an empty line.'
+
+readonly BODY_AND_FLAGS="$(tail -n +3 <<< "$COMMIT_MSG")"
+FLAGS=$(awk -v RS= '{paragraph=$0} END {print paragraph}' <<< "$BODY_AND_FLAGS")
+
+# Check whether the last paragraph of the body has flags (issue reference or commit variable).
+if grep -qP '^\w+\s*(=|#\d+)' <<< "$FLAGS"; then
+  ISSUE_REF="$(tail -n1 <<< "$FLAGS")"
+  # Check whether the last flag is an issue reference.
+  # TODO(cyrille): Check when there are both 'For' and 'Fix' references.
+  if [[ "$ISSUE_REF" =~ ^\w+\s*\#(\d+) ]]; then
+    # TODO(cyrille): Check multiple issue references.
+    readonly ISSUE_NUMBER="${BASH_REMATCH[0]}"
+    [[ $ISSUE_REF == "For #"$ISSUE_NUMBER ]] ||
+      [[ $ISSUE_REF == "Fix #"$ISSUE_NUMBER ]] ||
+      die 'Issue reference should either be introduced by "For" or "Fix".'
+    VARS="$(head -n -1 <<< "$FLAGS")"
+  else
+    VARS="$FLAGS"
+  fi
+  # Ensure there's no issue reference outside the last line of the flags.
+  grep -P '^\w+\s*#\d+' <<< "$VARS" &&
+    die 'Issue references should be on the last line of the message.'
+  # Ensure variables are uppercase.
+  grep -vP '^[A-Z]+\s*=' <<< "$VARS" &&
+    die 'Commit variables should be in uppercase.'
+  # Ensure variables are set without spacing.
+  grep -vP '^[A-Z]+=(\S|$)' <<< "$VARS" &&
+    die 'Commit variables assignment should be bash-like: "VAR=value".'
+else
+  FLAGS=""
+fi
+
+readonly BODY="$(head -n -"$(wc -l <<< "$FLAGS")" <<< "$BODY_AND_FLAGS")"
+[[ $(wc -L <<< "$BODY") -lt $BODY_MAX_LENGTH ]] ||
+  die 'Commit body should be no wider than '"$BODY_MAX_LENGTH"' chars.'
+


### PR DESCRIPTION
See the guide at https://github.com/bayesimpact/wiki/wiki/CommitMessageStyleGuide

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/170)
<!-- Reviewable:end -->
