### PR TITLE
[Bug Fix] Avoid submitting when local is different from remote.

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -149,7 +149,12 @@ if [ -z "${FORCE_PUSH}" ]; then
 fi
 
 if [ -n "$AUTO_SUBMIT" ]; then
-  GIT_SUBMIT_AUTO_MERGE=1 git submit
+  if [[ $(git rev-parse $BRANCH) == $(git rev-parse "$REMOTE_REPO/$REMOTE_BRANCH") ]]; then
+    GIT_SUBMIT_AUTO_MERGE=1 git submit
+  else
+    >&2 echo "Local branch is not in the same state as remote branch. Not submitting."
+    >&2 git status -uno
+  fi
 fi
 
 rm "${MESSAGE_FILE}"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/207)
<!-- Reviewable:end -->
