### PR TITLE
[Bug Fix] Enable auto-completion for 'git review'.

### DIFF
--- a/git-review.bash_completion
+++ b/git-review.bash_completion
@@ -47,7 +47,10 @@ _git_review()
 }
 
 if [ -n "$GIT_REVIEW_EXPERIMENTAL_PYTHON" ]; then
-  eval "$(register-python-argcomplete --external-argcomplete-script "$(dirname "${BASH_SOURCE[0]}")/bin/git-review.py" git-review)"
+  readonly PYTHON_SCRIPT="$(dirname $(readlink "${BASH_SOURCE[0]}"))/bin/git-review.py"
+  eval "$(register-python-argcomplete --external-argcomplete-script "$PYTHON_SCRIPT" git-review |
+    # Rename the auto-completion function to be caught by git completion.
+    sed 's!_python_argcomplete_'"$PYTHON_SCRIPT"'!_git_review!')"
 else
   complete -F _git_review git-review
 fi


### PR DESCRIPTION
The previous version only auto-completed 'git-review'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/245)
<!-- Reviewable:end -->
