### PR TITLE
[Easy Dev] Use python base instead of aruba.

### DIFF
--- a/git-custom-commands-test/Dockerfile
+++ b/git-custom-commands-test/Dockerfile
@@ -1,7 +1,12 @@
-FROM lascap/aruba-test
+FROM python:3.9
 
-# Install git.
-RUN apt-get update -qq && apt-get install -qqy git
+# Install git and ruby.
+RUN apt-get update -qq && apt-get install -qqy git ruby-full
+
+RUN mkdir /test
+WORKDIR /test
+
+RUN gem install contracts -v 0.16.1; gem install cucumber -v=2.3.2; gem install aruba -v=0.14.0
 
 # "Install" git-submit.
 ADD bin /usr/bin


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/319)
<!-- Reviewable:end -->
