### PR TITLE
[Clean Code] Use python git-review by default.

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -n "$GIT_REVIEW_EXPERIMENTAL_PYTHON" ]; then
+if [ -z "$NO_GIT_REVIEW_PYTHON" ]; then
   if shopt -po xtrace > /dev/null ; then
     readonly XTRACE='--xtrace ++'
   fi

--- a/git-review.bash_completion
+++ b/git-review.bash_completion
@@ -2,7 +2,7 @@
 #
 # bash completion support for git-review
 
-if [ -n "$GIT_REVIEW_EXPERIMENTAL_PYTHON" ]; then
+if [ -z "$NO_GIT_REVIEW_PYTHON" ]; then
   readonly PYTHON_SCRIPT="$HOME/.bayes-developer-setup/bin/git-review.py"
   eval "$(register-python-argcomplete --external-argcomplete-script "$PYTHON_SCRIPT" git-review |
     # Rename the auto-completion function to be caught by git completion.


### PR DESCRIPTION
This effectively deprecates bin/git-review.
Use NO_GIT_REVIEW_PYTHON env variable to keep the old behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/347)
<!-- Reviewable:end -->
