### PR TITLE
[Small Fix] Don't try to call bazel if not in a Bazel repo.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -62,7 +62,7 @@ function check_bazel_files() {
 }
 
 function check_bazel_tree() {
-  if [ -n "$GIT_COMMIT_IGNORE_BAZEL" ] || ! command -v bazel > /dev/null || test ! -f '.circleci/BUILD'; then
+  if [ -n "$GIT_COMMIT_IGNORE_BAZEL" ] || [ ! -f "WORKSPACE" ] || ! command -v bazel > /dev/null || test ! -f '.circleci/BUILD'; then
     return
   fi
   if ! bazel query 'deps(//.circleci/...)' > /dev/null; then


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/353)
<!-- Reviewable:end -->
