### PR TITLE
[Auto Complete] Auto-complete git submit -r same as git submit -a.

### DIFF
--- a/git-submit.bash_completion
+++ b/git-submit.bash_completion
@@ -22,7 +22,7 @@ __git_submit_options() {
         shift # past argument
         shift # past value
         ;;
-        -a|--abort)
+        -a|--abort|-r|--rebase)
         _GIT_SUBMIT_ABORT="$1"
         shift # past argument
         ;;


### PR DESCRIPTION
This is useful when autocompletion is used with the python script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/355)
<!-- Reviewable:end -->
