### PR TITLE
[Bug Fix] Genericize how git-python completion works.

### DIFF
--- a/git-review.bash_completion
+++ b/git-review.bash_completion
@@ -1,59 +1,64 @@
-#!bash
+#!/usr/bin/env bash
 #
 # bash completion support for git-review
 
-if [ -z "$NO_GIT_REVIEW_PYTHON" ]; then
-  readonly PYTHON_SCRIPT="$HOME/.bayes-developer-setup/bin/git-review.py"
-  eval "$(register-python-argcomplete --external-argcomplete-script "$PYTHON_SCRIPT" git-review |
+function set_python_git_completion() {
+  local python_script="$2" cmd="$1"
+  eval "$(register-python-argcomplete --external-argcomplete-script "$python_script" git-submit |
     # Rename the auto-completion function to be caught by git completion.
-    sed 's!_python_argcomplete_'"$PYTHON_SCRIPT"'!_git_review!' |
+    sed 's!_python_argcomplete_'"$PYTHON_SCRIPT"'!_git_'"$cmd"'!' |
     # Remove 'git' word from auto-completed line, to avoid parsing 'review' as an argument to the script.
-    sed '/_git_review/a\
+    sed '/_git_'"$cmd"'/a\
      [[ $COMP_LINE == "git "* ]] && COMP_LINE=${COMP_LINE:4} && ((COMP_POINT-=4));')"
-else
-  _git_review()
-  {
-    local cur=${COMP_WORDS[COMP_CWORD]}
-    local last=${cur##*,}
-    local prev=${cur%"$last"}
+}
 
-    local remote_repo="$(git remote | head -n 1)"
-    if [ -z "$remote_repo" ]; then
-      echo "No remote" 1>&2
-      return 1
-    fi
-    local remote_url="$(git config --get remote.$remote_repo.url)"
-
-    local reviewers=""
-
-    if [[ $remote_url == *"gitlab.com"* ]]; then
-      # GitLab
-
-      # Check if tool exists.
-      if [ -z "$(which gitlab)" ] || ! [ -x $(which gitlab) ]; then
-        # TODO(pascal): Fix the error reporting.
-        echo "gitlab tool is not installed, please install it:" 1>&2
-        echo "  https://github.com/bayesimpact/bayes-developer-setup/blob/HEAD/gitlab-cli.md" 1>&2
-        return 2
-      fi
-      # TODO(pascal): Use cache when/if it gets implemented;
-      # https://github.com/python-gitlab/python-gitlab/issues/758
-      local gitlab_project_name=${remote_url/git@gitlab.com:/}
-      gitlab_project_name=${gitlab_project_name/.git/}
-      local gitlab_project_id="$(gitlab project get --id "$gitlab_project_name" | grep ^id: | cut -d ' ' -f 2)"
-      reviewers="$(gitlab project-member list --project-id "$gitlab_project_id" | grep ^username: | cut -d ' ' -f 2)"
-    else
-      # GitHub
-
-      # TODO(cyrille): Add a nice error message when hub returns an error.
-      reviewers="$(hub api -t repos/{owner}/{repo}/assignees --cache 600 | grep login | cut -f 2)"
-    fi
-    local remaining_reviewers=$(echo "$reviewers $prev $prev" | tr ', ' "\n" | sort | uniq -u)
-    COMPREPLY=( $(compgen -P "$prev" -W "$remaining_reviewers" -- $last) )
-    if [[ ${#COMPREPLY[@]} == 1 ]] && [[ ${COMPREPLY[0]} == $cur ]] && [[ ${#remaining_reviewers} > 0 ]]; then
-      COMPREPLY=("$cur,")
-    fi
-  }
-
-  complete -F _git_review git-review
+if [ -z "$NO_GIT_REVIEW_PYTHON" ]; then
+  set_python_git_completion review "$HOME/.bayes-developer-setup/bin/git-review.py"
+  return
 fi
+
+_git_review()
+{
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local last=${cur##*,}
+  local prev=${cur%"$last"}
+
+  local remote_repo="$(git remote | head -n 1)"
+  if [ -z "$remote_repo" ]; then
+    echo "No remote" 1>&2
+    return 1
+  fi
+  local remote_url="$(git config --get remote.$remote_repo.url)"
+
+  local reviewers=""
+
+  if [[ $remote_url == *"gitlab.com"* ]]; then
+    # GitLab
+
+    # Check if tool exists.
+    if [ -z "$(which gitlab)" ] || ! [ -x $(which gitlab) ]; then
+      # TODO(pascal): Fix the error reporting.
+      echo "gitlab tool is not installed, please install it:" 1>&2
+      echo "  https://github.com/bayesimpact/bayes-developer-setup/blob/HEAD/gitlab-cli.md" 1>&2
+      return 2
+    fi
+    # TODO(pascal): Use cache when/if it gets implemented;
+    # https://github.com/python-gitlab/python-gitlab/issues/758
+    local gitlab_project_name=${remote_url/git@gitlab.com:/}
+    gitlab_project_name=${gitlab_project_name/.git/}
+    local gitlab_project_id="$(gitlab project get --id "$gitlab_project_name" | grep ^id: | cut -d ' ' -f 2)"
+    reviewers="$(gitlab project-member list --project-id "$gitlab_project_id" | grep ^username: | cut -d ' ' -f 2)"
+  else
+    # GitHub
+
+    # TODO(cyrille): Add a nice error message when hub returns an error.
+    reviewers="$(hub api -t repos/{owner}/{repo}/assignees --cache 600 | grep login | cut -f 2)"
+  fi
+  local remaining_reviewers=$(echo "$reviewers $prev $prev" | tr ', ' "\n" | sort | uniq -u)
+  COMPREPLY=( $(compgen -P "$prev" -W "$remaining_reviewers" -- $last) )
+  if [[ ${#COMPREPLY[@]} == 1 ]] && [[ ${COMPREPLY[0]} == $cur ]] && [[ ${#remaining_reviewers} > 0 ]]; then
+    COMPREPLY=("$cur,")
+  fi
+}
+
+complete -F _git_review git-review

--- a/git-submit.bash_completion
+++ b/git-submit.bash_completion
@@ -2,14 +2,18 @@
 #
 # bash completion support for git-submit
 
-if [ -z "$GIT_SUBMIT_EXPERIMENTAL_PYTHON" ]; then
-  readonly PYTHON_SCRIPT="$HOME/.bayes-developer-setup/bin/git-submit.py"
-  eval "$(register-python-argcomplete --external-argcomplete-script "$PYTHON_SCRIPT" git-submit |
+function set_python_git_completion() {
+  local python_script="$2" cmd="$1"
+  eval "$(register-python-argcomplete --external-argcomplete-script "$python_script" git-submit |
     # Rename the auto-completion function to be caught by git completion.
-    sed 's!_python_argcomplete_'"$PYTHON_SCRIPT"'!_git_submit!' |
+    sed 's!_python_argcomplete_'"$PYTHON_SCRIPT"'!_git_'"$cmd"'!' |
     # Remove 'git' word from auto-completed line, to avoid parsing 'submit' as an argument to the script.
-    sed '/_git_submit/a\
+    sed '/_git_'"$cmd"'/a\
      [[ $COMP_LINE == "git "* ]] && COMP_LINE=${COMP_LINE:4} && ((COMP_POINT-=4));')"
+}
+
+if [ -z "$GIT_SUBMIT_EXPERIMENTAL_PYTHON" ]; then
+  set_python_git_completion "submit" "$HOME/.bayes-developer-setup/bin/git-submit.py"
   return
 fi
 readonly ALL_OPTIONS=" -a --abort -f --force -u --user "


### PR DESCRIPTION
This fixes a bug where the autocompletion for git-review
was used for git-submit, because the variable PYTHON_SCRIPT
was readonly in both sourced scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/bayes-developer-setup/382)
<!-- Reviewable:end -->
